### PR TITLE
Extend the list of unsafe SVG element attributes

### DIFF
--- a/src/main/java/io/github/borewit/sanitize/SVGSanitizer.java
+++ b/src/main/java/io/github/borewit/sanitize/SVGSanitizer.java
@@ -47,7 +47,87 @@ public class SVGSanitizer {
       Set.of("script", "foreignObject", "iframe", "embed", "object");
 
   private static final Set<String> UNSAFE_ATTRIBUTES =
-      Set.of("onload", "onclick", "onmouseover", "onerror", "onfocus", "onblur", "onkeydown");
+      Set.of(
+          // Mouse events
+          "onclick",
+          "ondblclick",
+          "onmousedown",
+          "onmouseup",
+          "onmouseover",
+          "onmousemove",
+          "onmouseout",
+          "onmouseenter",
+          "onmouseleave",
+
+          // Keyboard events
+          "onkeydown",
+          "onkeypress",
+          "onkeyup",
+
+          // Form events
+          "onfocus",
+          "onblur",
+          "onchange",
+          "oninput",
+          "onselect",
+          "onsubmit",
+          "onreset",
+
+          // Window events
+          "onload",
+          "onunload",
+          "onresize",
+          "onscroll",
+          "onerror",
+
+          // Drag & drop events
+          "ondrag",
+          "ondragend",
+          "ondragenter",
+          "ondragleave",
+          "ondragover",
+          "ondragstart",
+          "ondrop",
+
+          // Clipboard events
+          "oncopy",
+          "oncut",
+          "onpaste",
+
+          // Media events
+          "onplay",
+          "onpause",
+          "onplaying",
+          "oncanplay",
+          "oncanplaythrough",
+          "onended",
+          "onloadeddata",
+          "onloadedmetadata",
+          "onloadstart",
+          "onprogress",
+          "onratechange",
+          "onseeked",
+          "onseeking",
+          "onstalled",
+          "onsuspend",
+          "ontimeupdate",
+          "onvolumechange",
+          "onwaiting",
+
+          // Misc events
+          "onwheel",
+          "oncontextmenu",
+          "ontoggle",
+          "onanimationstart",
+          "onanimationend",
+          "onanimationiteration",
+          "ontransitionend",
+
+          // Touch events (MOBILE)
+          "ontouchstart",
+          "ontouchend",
+          "ontouchmove",
+          "ontouchcancel");
 
   /**
    * Sanitizes the given SVG content string by removing unsafe elements and attributes.

--- a/src/test/java/io/github/borewit/sanitize/SVGSanitizerTest.java
+++ b/src/test/java/io/github/borewit/sanitize/SVGSanitizerTest.java
@@ -383,8 +383,31 @@ class SVGSanitizerTest {
 
     assertTrue(
         CheckSvg.containsStyleElement(sanitizedSvg),
-        String.format("Sanitized SVG \"%s\" contain a style element", svgTestFile));
+        String.format("Sanitized SVG \"%s\" contains a style element", svgTestFile));
 
     assertFalse(sanitizedSvg.contains("evil.css"), "Should not contain any external URLs");
+  }
+
+  @Test
+  @DisplayName("Sanitize ontouchstart")
+  void clearOnTouchStart() throws Exception {
+    String svgTestFile = "ontouchstart.svg";
+
+    // Convert output to string for verification
+    String dirtySvg = this.getFixtureAsString(svgTestFile);
+
+    assertTrue(
+        CheckSvg.containsJavaScript(dirtySvg),
+        String.format("Dirty SVG \"%s\" contains ontouchstart attribute", svgTestFile));
+
+    // Convert output to string for verification
+    String sanitizedSvg = SVGSanitizer.sanitize(dirtySvg);
+
+    assertFalse(
+        CheckSvg.containsJavaScript(sanitizedSvg),
+        String.format(
+            "Sanitized SVG \"%s\" should not contain ontouchstart attribute", svgTestFile));
+
+    System.out.println(sanitizedSvg);
   }
 }

--- a/src/test/resources/ontouchstart.svg
+++ b/src/test/resources/ontouchstart.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 124 124" width="400" fill="none" height="400">
+  <rect rx="24" ontouchstart="alert(1)" width="124" fill="#000000" height="124"></rect>
+</svg>


### PR DESCRIPTION
Extend the list of unsafe SVG element attributes, including `ontouchstart`.

Resolves #34

See also PR #36.