### PR TITLE
Add "SVG security best practices", based on Stackoverflow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,9 @@ public static InputStream sanitize(InputStream inputStream)
 ```
 Acts as a filter, returning a new `InputStream` with the sanitized SVG.
 
+## Security considerations
+User-uploaded SVGs can contain malicious content that may be executed in a browser context. Sanitizing SVGs is an important step, but should be combined with other measures for full protection.
+See [SVG security best practices](SVG-security-best-practices.md) for a broader overview.
+
 ## License
 This project is licensed under the [MIT License](LICENSE.txt)

--- a/SVG-security-best-practices.md
+++ b/SVG-security-best-practices.md
@@ -1,0 +1,69 @@
+# SVG security best practices
+
+User-uploaded SVG files may embed malicious code or include it via an external reference.
+When a malicious SVG file is published on your website,
+it can be used to exploit multiple attack vectors, including:
+
+- [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/):
+  executing JavaScript inside the SVG to steal cookies, session tokens, or perform actions on behalf of the user.
+- [Data exfiltration](https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html#rule-2---avoid-documentwrite) via external resource loading:
+  Using `<image>`, `<script>`, or `<use>` tags to send sensitive information to attacker-controlled servers.
+- [Phishing overlays](https://owasp.org/www-community/attacks/Clickjacking):
+  creating deceptive clickable areas or visual elements to trick users into revealing credentials.
+- Local file access: embed `<image xlink:href="file:///...">` or `<use>` references to attempt to read local or server-side files.
+
+There are **3 measures** I can recommend to avoid your website being vulnerable to such attacks.
+Best to apply them all of them:
+
+#### 1: Wrap the SVG in an `<img>` Tag
+
+Instead of directly embedding an SVG using `<svg>` or `<object>`, use the `<img>` tag to render it:
+
+```html
+<img src="safe-image.svg" alt="Safe SVG">
+```
+
+
+The `<img>` tag ensures that the SVG is treated as an image and prevents JavaScript execution inside it,
+but it doesn’t remove malicious code from the SVG file.
+
+**Please be aware** that this measure alone is insufficient.
+If a user opens the SVG file directly in a new browser tab or window,
+the protection provided by the `<img>` wrapper is bypassed and any malicious code within the SVG may still execute.
+
+#### 2: Apply a Content Security Policy (CSP) header
+Enabling the [Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/Guides/CSP)
+_HTTP response header_ also prevents JavaScript execution inside the SVG.
+
+For example:
+
+```text
+Content-Security-Policy: default-src 'none'; img-src 'self'; style-src 'none'; script-src 'none'; sandbox
+```
+
+Which applies the following policy:
+
+| **Directive** | **Purpose** |
+| --- | --- |
+| `default-src 'none'` | Blocks all content by default. |
+| `img-src 'self'` | Allows images only from the same origin. |
+| `style-src 'none'` | Prevents inline and external CSS styles. |
+| `script-src 'none'` | Blocks inline and external JavaScript to prevent XSS. |
+| `sandbox` | Disables scripts, forms, and top-level navigation for the SVG. |
+
+#### 3: Server-side sanitization of uploaded SVGs
+
+Strip potentially harmful elements like `<script>`, `<iframe>`, `<foreignObject>`,
+inline event handlers (e.g. `onclick`) or inclusion of other (potentially malicious) files.
+
+Examples of libraries for SVG sanitization:
+- Java: [SVG Sanitizer](https://github.com/Borewit/svg-sanitizer)
+- JavaScript: [DOMPurify](https://github.com/cure53/DOMPurify)
+- PHP: [svg-sanitizer](https://github.com/darylldoyle/svg-sanitizer)
+- Python: [py-svg-hush](https://github.com/jams2/py-svg-hush)
+
+#### Alternative: Rasterize SVG server-side
+
+Render the SVG server side to a [raster based format](https://en.wikipedia.org/wiki/Raster_graphics), like PNG.
+This may protect visiting users, but could introduce vulnerabilities at the rendering side at the server,
+especially using server side JavaScript (like Node.js).


### PR DESCRIPTION
Adds a page of more generic guidance, in addition to the README.
I choose to use a different page, as I believe the README should be focussed on this project.
This guidance is broader then that, yet I think it worth to make it part of the project some broader advice how to deal with uploaded SVGs on a website, to encourage users to take additional security measures. 
 