### PR TITLE
Normalize xlink namespace to SVG namespace / SVG 2.0

### DIFF
--- a/src/test/java/io/github/borewit/sanitize/SVGAttributeTest.java
+++ b/src/test/java/io/github/borewit/sanitize/SVGAttributeTest.java
@@ -209,6 +209,10 @@ public class SVGAttributeTest {
       lowerCaseAttributes.add(attribute.toLowerCase());
     }
 
+    for (String attribute : SVGSanitizer.SAFE_XML_ATTRIBUTES) {
+      lowerCaseAttributes.add(attribute.toLowerCase());
+    }
+
     lowerCaseAttributes.add("href"); // xlink attribute
 
     for (String attribute : SVGSanitizer.SAFE_SVG_DEPRECATED_ATTRIBUTES) {

--- a/src/test/java/io/github/borewit/sanitize/SVGSanitizerTest.java
+++ b/src/test/java/io/github/borewit/sanitize/SVGSanitizerTest.java
@@ -202,7 +202,7 @@ class SVGSanitizerTest {
   }
 
   @Test
-  @DisplayName("Preserve local anchor xlink:href")
+  @DisplayName("Convert xlink SVG 2 namespace and preserve local reference")
   void preserveLocalAnchorXLinkHref() throws Exception {
     String svgTestFile = "Flag_of_the_United_States.svg";
     // Convert output to string for verification
@@ -212,6 +212,10 @@ class SVGSanitizerTest {
         String.format("Dirty \"%s\" should contain internal references", svgTestFile));
 
     String sanitizedSvg = SVGSanitizer.sanitize(dirtySvg);
+
+    assertFalse(sanitizedSvg.contains("xlink:href=\""), "should not contain any xlink attributes");
+    assertTrue(
+        sanitizedSvg.contains("<use href=\"#s\" y=\"420\"/>"), "should preserve local references");
 
     // Save sanitized SVG for debugging
     saveSvg(sanitizedSvg, svgTestFile);

--- a/src/test/resources/svg-xml-hash-map.json
+++ b/src/test/resources/svg-xml-hash-map.json
@@ -8,7 +8,7 @@
   "eicar.svg" : "7d7560b91affedef4f395aef312435e84825eb186f1d42c79f980b53a490de84",
   "externalimage.svg" : "4ba2ad7d20adfcd7d75b86cf57b1ae7fb759322ab14f4fbd7b119ea9fbb046bb",
   "externalimage2.svg" : "cd79c741d81e781f389438788f376a0d007e2e3ad3dcb885850959cda3c9ba37",
-  "Flag_of_the_United_States.svg" : "249a930f7adc0e078bc8167998b6a9558e4e06c5e3b099e3af419bd23c67be97",
+  "Flag_of_the_United_States.svg" : "b1d0f7b64d09d25b7d5e337a3ba111788e64e432e564c08dba65d8ead4f67826",
   "form-action-case.svg" : "44eddf60cc1f0c6c37111c478fa8e0d432ca8350b130b6022df34149640bcd4b",
   "form-action.svg" : "7e2e6328e7b0f47b022d10ce8b4fe843ccf651e1ded833b9e8f1e783f3227b13",
   "form-action2-case.svg" : "ba86c67cc703779b689f7aa31ff31216e6f02a36431f5b6af24cf1f23c72040f",


### PR DESCRIPTION
Normalize xlink namespace to SVG namespace / SVG 2.0

Ref:
- [MDN: deprecated `xlink:href`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/xlink:href)

Technical debt:
- The xlink namespace declaration may still be present, although unused